### PR TITLE
debian/backports-wireless-3.19.0-28.install: fixing path

### DIFF
--- a/debian/backports-wireless-3.19.0-28.install
+++ b/debian/backports-wireless-3.19.0-28.install
@@ -1,2 +1,2 @@
-./debian/tmp/lib/modules/3.19.0-28-generic/updates/lib/modules/3.19.0-28-generic/extra/drivers/net/ethernet/intel/igb/igb.ko /lib/modules/3.19.0-28-generic/extra/drivers/net/ethernet/intel/igb
-./debian/tmp/lib/modules/3.19.0-28-generic/updates/lib/modules/3.19.0-28-generic/extra/compat/compat.ko /lib/modules/3.19.0-28-generic/extra/compat
+lib/modules/3.19.0-28-generic/updates/lib/modules/3.19.0-28-generic/extra/drivers/net/ethernet/intel/igb/igb.ko /lib/modules/3.19.0-28-generic/extra/drivers/net/ethernet/intel/igb
+lib/modules/3.19.0-28-generic/updates/lib/modules/3.19.0-28-generic/extra/compat/compat.ko /lib/modules/3.19.0-28-generic/extra/compat


### PR DESCRIPTION
dh_install automatically looking in debian/tmp, no need
to add debian/tmp at the begining of the path

Signed-off-by: Phidias Chiang phidias.chiang@canonical.com
